### PR TITLE
Increase `psr/log` requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "hofff/contao-root-relations": "^3.0",
     "menatwork/contao-multicolumnwizard-bundle": "^3.5",
     "netzmacht/contao-toolkit": "^3.8",
-    "psr/log": "^1.0",
+    "psr/log": "^1.0 || ^2.0 || ^3.0",
     "symfony/asset": "^5.4",
     "symfony/config": "^5.4",
     "symfony/dependency-injection": "^5.4",


### PR DESCRIPTION
This PR increases the `psr/log` requirement for easier installation in Contao. Currently you can only install this extension with

```
composer require netzmacht/contao-i18n --no-update && composer update
```

or

```
composer require netzmacht/contao-i18n -W
```

or by adding in the Contao Manager and then "Update all packages" (rather than "Apply").

With this change the extension can be installed regularly (i.e. without having to downgrade `psr/log`).